### PR TITLE
Improvements for building the package

### DIFF
--- a/RasterToSIISLP.cxx
+++ b/RasterToSIISLP.cxx
@@ -33,11 +33,13 @@
 
 #include <cups/cups.h>
 #include <cups/raster.h>
+#include <cups/ppd.h>
 
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <vector>
+#include <cstdio>
 
 #include "SeikoSLPCommands.h"
 #include "SeikoInstrumentsVendorID.h"

--- a/makefile
+++ b/makefile
@@ -23,8 +23,8 @@
 
 mfdir     := $(shell pwd)
 program   := seikoslp.rastertolabel
-ppddir    := $(shell cups-config --datadir)/model/seiko
-filterdir := $(shell cups-config --serverbin)/filter
+ppddir    := $(DESTDIR)$(shell cups-config --datadir)/model/seiko
+filterdir := $(DESTDIR)$(shell cups-config --serverbin)/filter
 cflags    := $(shell cups-config --ldflags --cflags)
 ldflags   := $(shell cups-config --image --libs)
 
@@ -50,8 +50,9 @@ build:
 
 install:
 	make build
+	mkdir -p "$(filterdir)"
 	mv $(program) "$(filterdir)/"
-	mkdir "$(ppddir)"
+	mkdir -p "$(ppddir)"
 	gzip -c siislp100.ppd >> siislp100.ppd.gz
 	gzip -c siislp200.ppd >> siislp200.ppd.gz
 	gzip -c siislp240.ppd >> siislp240.ppd.gz

--- a/makefile
+++ b/makefile
@@ -25,6 +25,8 @@ mfdir     := $(shell pwd)
 program   := seikoslp.rastertolabel
 ppddir    := $(DESTDIR)$(shell cups-config --datadir)/model/seiko
 filterdir := $(DESTDIR)$(shell cups-config --serverbin)/filter
+ppddestdir    := $(DESTDIR)$(ppddir)
+filterdestdir := $(DESTDIR)$(filterdir)
 cflags    := $(shell cups-config --ldflags --cflags)
 ldflags   := $(shell cups-config --image --libs)
 
@@ -50,9 +52,9 @@ build:
 
 install:
 	make build
-	mkdir -p "$(filterdir)"
-	mv $(program) "$(filterdir)/"
-	mkdir -p "$(ppddir)"
+	mkdir -p "$(filterdestdir)"
+	mv $(program) "$(filterdestdir)/"
+	mkdir -p "$(ppddestdir)"
 	gzip -c siislp100.ppd >> siislp100.ppd.gz
 	gzip -c siislp200.ppd >> siislp200.ppd.gz
 	gzip -c siislp240.ppd >> siislp240.ppd.gz
@@ -60,11 +62,11 @@ install:
 	gzip -c siislp450.ppd >> siislp450.ppd.gz
 	gzip -c siislp620.ppd >> siislp620.ppd.gz
 	gzip -c siislp650.ppd >> siislp650.ppd.gz
-	mv *.ppd.gz "$(ppddir)"
+	mv *.ppd.gz "$(ppddestdir)"
 
 uninstall:
-	rm -rfv "$(ppddir)"
-	rm -rfv "$(filterdir)/$(program)"
+	rm -rfv "$(ppddestdir)"
+	rm -rfv "$(filterdestdir)/$(program)"
 
 clean:
 	rm -f $(program) *.o *~

--- a/makefile
+++ b/makefile
@@ -31,7 +31,6 @@ cflags    := $(shell cups-config --ldflags --cflags)
 ldflags   := $(shell cups-config --image --libs)
 
 build:
-	make clean
 	$(CXX) -o $(program) $(cflags) *.cxx $(ldflags)
 	# set up the filter directory in the ppd correctly.
 	perl -p -i -e 's(^.cupsFilter.*\Z) <*cupsFilter: "application/vnd.cups-raster 0 $(filterdir)/$(program)">g' siislp100.ppd
@@ -51,7 +50,6 @@ build:
 	perl -p -i -e "s#\(^.APPrinterIconPath.*\$\)\n##g" siislp650.ppd
 
 install:
-	make build
 	mkdir -p "$(filterdestdir)"
 	mv $(program) "$(filterdestdir)/"
 	mkdir -p "$(ppddestdir)"


### PR DESCRIPTION
I tried to build this package on Arch Linux. I had two problems:

1. It didn't build due to some missing includes. I added the necessary includes.

2. I wanted to create a package out of the driver. To do this, it is necessary that the Makefile supports the DESTDIR variable. I added it to the Makefile.

By the way: There are at least two other repositories with this driver:
danieloneill/SeikoSLPLinuxDriver and hholzgra/sii_440_cups. The first one seems to have a slightly modified version of the original driver. The later one seems to be a version with less printers supported. It would be nice, if they could be somehow connected on github so that someone who finds one of the repos can also look for improvements in others. Do you have an idea how that might work?